### PR TITLE
fix bug where buy will succeed if user does not exist

### DIFF
--- a/StockTrader/src/main/java/com/restResource/StockTrader/controller/BuyController.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/controller/BuyController.java
@@ -59,7 +59,12 @@ public class BuyController {
         // Removing more funds then is available will violate the amount >= 0
         // constraint which will throw an exception.
         try {
-            accountRepository.removeFunds(userId, roundedAmount);
+            Integer updatedEntriesCount = accountRepository.removeFunds(userId, roundedAmount);
+            if (updatedEntriesCount != 1) {
+                throw new IllegalStateException(
+                        "Error removing funds from account. Expected 1 account to be updated but " +
+                                updatedEntriesCount + " accounts were updated");
+            }
         } catch (Exception e) {
             // TODO: may want to handle this differently.
             throw new IllegalStateException("You do not have enough funds.");

--- a/StockTrader/src/main/java/com/restResource/StockTrader/repository/AccountRepository.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/repository/AccountRepository.java
@@ -23,6 +23,6 @@ public interface AccountRepository extends CrudRepository<Account, String> {
     @Transactional
     @Query(value = "UPDATE account SET amount = amount - ?2 WHERE user_id = ?1",
             nativeQuery = true)
-    void removeFunds(String userId, Integer amount);
+    Integer removeFunds(String userId, Integer amount);
 
 }


### PR DESCRIPTION
The removeFunds query does not error if no accounts are updated, so if the user did not exist the create buy would succeed. Added check to make sure exactly one account was updated.