### PR TITLE
Add account transaction log db

### DIFF
--- a/StockTrader/src/main/java/com/restResource/StockTrader/entity/Account.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/entity/Account.java
@@ -16,6 +16,7 @@ import javax.validation.constraints.Min;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Account {
+    @Min(value = 0)
     Integer amount;
     @Id //sets the pkey to userId
     String userId;

--- a/StockTrader/src/main/java/com/restResource/StockTrader/entity/Account.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/entity/Account.java
@@ -16,7 +16,6 @@ import javax.validation.constraints.Min;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Account {
-    @Min(value = 0)
     Integer amount;
     @Id //sets the pkey to userId
     String userId;

--- a/StockTrader/src/main/java/com/restResource/StockTrader/repository/InvestmentRepository.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/repository/InvestmentRepository.java
@@ -11,7 +11,7 @@ public interface InvestmentRepository extends CrudRepository<Investment, Investm
     @Modifying
     @Transactional
     @Query(value =
-            "INSERT INTO investment VALUES (?1, ?2, ?3) " +
+            "INSERT INTO investment (owner, stock_symbol, stock_count) VALUES (?1, ?2, ?3) " +
             "ON CONFLICT (owner, stock_symbol) DO UPDATE " +
             "SET stock_count = investment.stock_count + ?3",
             nativeQuery = true)

--- a/StockTrader/src/main/resources/application.properties
+++ b/StockTrader/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.datasource.url=jdbc:postgresql://localhost:5432/stocktraderdb
 spring.datasource.username=postgres
 spring.datasource.password=postgres
 spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.initialization-mode=always
 # ===============================
 # = JPA / HIBERNATE
 # ===============================
@@ -13,7 +14,8 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.show-sql=true
 # Hibernate ddl auto (create, create-drop, update): with "create-drop" the database
 # schema will be automatically created afresh for every start of application
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
+
 
 # Naming strategy
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyHbmImpl

--- a/StockTrader/src/main/resources/schema.sql
+++ b/StockTrader/src/main/resources/schema.sql
@@ -1,3 +1,4 @@
+-- TODO: properly config application.properties so I don't have to drop tables.
 DROP TABLE IF EXISTS pending_buy;
 DROP TABLE IF EXISTS pending_sell;
 DROP TABLE IF EXISTS investment;
@@ -60,10 +61,11 @@ DECLARE
     action varchar;
     funds integer;
 BEGIN
+    -- For inserts (ie. new accounts), treat previous amount as 0.
      IF (OLD IS NULL) THEN
         OLD.amount = 0;
      END IF;
-     IF (OLD.amount < NEW.amount OR OLD IS NULL) THEN
+     IF (OLD.amount < NEW.amount) THEN
         action = ''add'';
         funds = New.amount - OLD.amount;
       ELSIF (OLD.amount > NEW.amount) THEN
@@ -81,4 +83,5 @@ END;
 CREATE TRIGGER log_account_transaction AFTER INSERT OR UPDATE ON account
     FOR EACH ROW EXECUTE PROCEDURE log_account_transaction();
 
-CREATE TEMP SEQUENCE hibernate_sequence START 1;
+DROP SEQUENCE IF EXISTS hibernate_sequence;
+CREATE SEQUENCE hibernate_sequence START 1;

--- a/StockTrader/src/main/resources/schema.sql
+++ b/StockTrader/src/main/resources/schema.sql
@@ -1,0 +1,84 @@
+DROP TABLE IF EXISTS pending_buy;
+DROP TABLE IF EXISTS pending_sell;
+DROP TABLE IF EXISTS investment;
+DROP TABLE IF EXISTS account;
+DROP TABLE IF EXISTS account_transaction_log;
+DROP TABLE IF EXISTS user_command_log;
+
+CREATE TABLE pending_buy (
+    id integer PRIMARY KEY,
+    price integer,
+    amount integer CHECK (amount >= 0),
+    timestamp timestamp without time zone,
+    user_id varchar(255),
+    stock_symbol varchar(255)
+);
+
+CREATE TABLE pending_sell (
+    id integer PRIMARY KEY,
+    stock_count integer CHECK (stock_count >= 0),
+    stock_price integer,
+    timestamp timestamp without time zone,
+    user_id varchar(255),
+    stock_symbol varchar(255)
+);
+
+CREATE TABLE investment (
+    owner varchar(255),
+    stock_count integer CHECK (stock_count >= 0),
+    stock_symbol varchar(255),
+    PRIMARY KEY (owner, stock_symbol)
+);
+
+CREATE TABLE account (
+    user_id varchar(255) PRIMARY KEY,
+    amount integer CHECK (amount >= 0)
+);
+
+CREATE TABLE account_transaction_log (
+    action varchar,
+    funds integer,
+    timestamp timestamp,
+    username varchar
+);
+
+CREATE TABLE user_command_log (
+    transaction_num integer,
+    timestamp timestamp without time zone,
+    server varchar(255),
+    command varchar(255),
+    username varchar(255),
+    stock_symbol varchar(255),
+    filename varchar(255),
+    funds integer
+);
+
+
+
+CREATE OR REPLACE FUNCTION log_account_transaction() RETURNS trigger AS '
+DECLARE
+    action varchar;
+    funds integer;
+BEGIN
+     IF (OLD IS NULL) THEN
+        OLD.amount = 0;
+     END IF;
+     IF (OLD.amount < NEW.amount OR OLD IS NULL) THEN
+        action = ''add'';
+        funds = New.amount - OLD.amount;
+      ELSIF (OLD.amount > NEW.amount) THEN
+        action = ''remove'';
+        funds = OLD.amount - NEW.amount;
+      ELSE
+        RETURN NULL;
+      END IF;
+      INSERT INTO account_transaction_log (action, funds, timestamp, username)
+      VALUES (action, funds, NOW(), NEW.user_id);
+      RETURN NULL;
+END;
+' LANGUAGE plpgsql;
+
+CREATE TRIGGER log_account_transaction AFTER INSERT OR UPDATE ON account
+    FOR EACH ROW EXECUTE PROCEDURE log_account_transaction();
+
+CREATE TEMP SEQUENCE hibernate_sequence START 1;


### PR DESCRIPTION
Add account transaction log by creating a trigger on account insert or update.
Unfortunately, this seems to require using a schema.sql file which means we can no longer use hibernates table auto-generation. It may be a good thing to get away from auto-generation because it does allow us to use some more powerful DB features.