### PR TITLE
Fix marshaller

### DIFF
--- a/StockTrader/src/main/java/com/restResource/StockTrader/service/LoggingService.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/service/LoggingService.java
@@ -18,7 +18,6 @@ public class LoggingService {
 
     private LogXmlRepository logXmlRepository;
     private JAXBContext jaxbContext;
-    private Marshaller marshaller;
 
     public LoggingService(
                           LogXmlRepository logXmlRepository
@@ -26,11 +25,21 @@ public class LoggingService {
         this.logXmlRepository = logXmlRepository;
         try {
             this.jaxbContext = JAXBContext.newInstance(UserCommandLog.class,QuoteServerLog.class,SystemEventLog.class,ErrorEventLog.class,DebugEventLog.class);
-            this.marshaller = jaxbContext.createMarshaller();
-            // TODO: make this false which will save space in database
-            this.marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, false);
-            this.marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
+
         } catch( Exception e ) {
+            e.printStackTrace();
+        }
+
+    }
+
+    private Marshaller createMarshaller() {
+        try {
+            Marshaller marshaller = this.jaxbContext.createMarshaller();
+            // TODO: make this false which will save space in database
+            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, false);
+            marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
+            return marshaller;
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -49,6 +58,7 @@ public class LoggingService {
         StringWriter writer = new StringWriter();
 
         try {
+            Marshaller marshaller = createMarshaller();
             marshaller.marshal(log,writer);
             xmlLogEvent(
                     LogXml.builder()
@@ -77,6 +87,7 @@ public class LoggingService {
         StringWriter writer = new StringWriter();
 
         try {
+            Marshaller marshaller = createMarshaller();
             marshaller.marshal(log,writer);
             xmlLogEvent(
                     LogXml.builder()
@@ -107,6 +118,7 @@ public class LoggingService {
         StringWriter writer = new StringWriter();
 
         try {
+            Marshaller marshaller = createMarshaller();
             marshaller.marshal(log,writer);
             xmlLogEvent(
                     LogXml.builder()
@@ -135,6 +147,7 @@ public class LoggingService {
 
         StringWriter writer = new StringWriter();
         try {
+            Marshaller marshaller = createMarshaller();
             marshaller.marshal(log,writer);
             xmlLogEvent(
                     LogXml.builder()
@@ -162,6 +175,7 @@ public class LoggingService {
                 .build();
         StringWriter writer = new StringWriter();
         try {
+            Marshaller marshaller = createMarshaller();
             marshaller.marshal(log,writer);
             xmlLogEvent(
                     LogXml.builder()

--- a/StockTrader/src/main/java/com/restResource/StockTrader/service/LoggingService.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/service/LoggingService.java
@@ -7,6 +7,7 @@ import org.apache.catalina.User;
 import org.springframework.stereotype.Service;
 
 import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.annotation.XmlElement;
 import java.io.File;
@@ -32,18 +33,12 @@ public class LoggingService {
 
     }
 
-    private Marshaller createMarshaller() {
-        try {
-            Marshaller marshaller = this.jaxbContext.createMarshaller();
-            // TODO: make this false which will save space in database
-            marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, false);
-            marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
-            return marshaller;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-
+    private Marshaller createMarshaller() throws JAXBException {
+        Marshaller marshaller = this.jaxbContext.createMarshaller();
+        // TODO: make this false which will save space in database
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, false);
+        marshaller.setProperty(Marshaller.JAXB_FRAGMENT, true);
+        return marshaller;
     }
 
     public void xmlLogEvent(LogXml log) {

--- a/StockTrader/src/main/java/com/restResource/StockTrader/service/LoggingService.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/service/LoggingService.java
@@ -41,6 +41,7 @@ public class LoggingService {
             return marshaller;
         } catch (Exception e) {
             e.printStackTrace();
+            return null;
         }
 
     }


### PR DESCRIPTION
Always create new Marshaller, which resolves the ArrayIndexOutOfBoundsExceptions that were happening.
Marshallers are apparently supposed to be created new every time as mentioned in [here](https://stackoverflow.com/questions/46407590/jaxb-parsing-error-arrayindexoutofboundsexception)

Tested by running the 10 user workload file and no ArrayIndexOutOfBoundsExceptions occured. 