### PR TITLE
Modify account logs to use transaction server time

### DIFF
--- a/StockTrader/src/main/java/com/restResource/StockTrader/controller/AddController.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/controller/AddController.java
@@ -3,7 +3,7 @@ import com.restResource.StockTrader.entity.CommandType;
 import com.restResource.StockTrader.entity.logging.DebugEventLog;
 import com.restResource.StockTrader.entity.logging.ErrorEventLog;
 import com.restResource.StockTrader.entity.logging.UserCommandLog;
-import com.restResource.StockTrader.repository.AccountRepository;
+import com.restResource.StockTrader.service.AccountService;
 import com.restResource.StockTrader.service.LoggingService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -11,12 +11,12 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class AddController {
 
-    private AccountRepository accountRepository;
+    private AccountService accountService;
     private LoggingService loggingService;
 
-    public AddController(AccountRepository accountRepository,
+    public AddController(AccountService accountService,
                          LoggingService loggingService) {
-        this.accountRepository = accountRepository;
+        this.accountService = accountService;
         this.loggingService = loggingService;
     }
 
@@ -39,7 +39,7 @@ public class AddController {
                 throw new IllegalArgumentException(
                         "The ADD amount parameter must be greater than zero");
             } else {
-                accountRepository.updateAccountBalance(userId, amount,transactionNum,"TS1");
+                accountService.updateAccountBalance(userId, amount,transactionNum);
             }
             return HttpStatus.OK;
         } catch (Exception e) {

--- a/StockTrader/src/main/java/com/restResource/StockTrader/controller/BuyTriggerController.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/controller/BuyTriggerController.java
@@ -5,7 +5,7 @@ import com.restResource.StockTrader.entity.CommandType;
 import com.restResource.StockTrader.entity.TriggerKey;
 import com.restResource.StockTrader.entity.logging.ErrorEventLog;
 import com.restResource.StockTrader.entity.logging.UserCommandLog;
-import com.restResource.StockTrader.repository.AccountRepository;
+import com.restResource.StockTrader.service.AccountService;
 import com.restResource.StockTrader.repository.BuyTriggerRepository;
 import com.restResource.StockTrader.service.BuyTriggerService;
 import com.restResource.StockTrader.service.LoggingService;
@@ -20,7 +20,7 @@ import java.util.Optional;
 @RequestMapping(value = "/buyTrigger")
 public class BuyTriggerController {
 
-    private AccountRepository accountRepository;
+    private AccountService accountService;
 
     private LoggingService loggingService;
 
@@ -32,12 +32,12 @@ public class BuyTriggerController {
             BuyTriggerRepository buyTriggerRepository,
             LoggingService loggingService,
             BuyTriggerService buyTriggerService,
-            AccountRepository accountRepository) {
+            AccountService accountService) {
 
         this.buyTriggerRepository = buyTriggerRepository;
         this.loggingService = loggingService;
         this.buyTriggerService = buyTriggerService;
-        this.accountRepository = accountRepository;
+        this.accountService = accountService;
     }
 
     @PostMapping(path = "/amount")
@@ -64,7 +64,7 @@ public class BuyTriggerController {
             //TODO remove the find by and replace it with a create or incremement function
             Optional<BuyTrigger> stockBuyTriggerStatus = buyTriggerRepository.findByUserIdAndStockSymbol(userId, stockSymbol);
 
-            if (accountRepository.removeFunds(userId, stockAmount, transactionNum, "TS1") == 0) {
+            if (accountService.removeFunds(userId, stockAmount, transactionNum) == 0) {
                 //insufficient funds for the transaction.
                 throw new IllegalArgumentException("Insufficient Funds for the Transaction - requesting to remove: " + stockAmount);
             }
@@ -161,7 +161,7 @@ public class BuyTriggerController {
 
             //refund the money
             //TODO add a check here to make sure it worked
-            accountRepository.updateAccountBalance(userId, stockBuyTriggerStatus.get().getStockAmount(),transactionNum, "TS1");
+            accountService.updateAccountBalance(userId, stockBuyTriggerStatus.get().getStockAmount(),transactionNum);
             TriggerKey triggerKey = TriggerKey.builder()
                     .userId(userId)
                     .stockSymbol(stockSymbol)

--- a/StockTrader/src/main/java/com/restResource/StockTrader/controller/SellController.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/controller/SellController.java
@@ -3,7 +3,7 @@ package com.restResource.StockTrader.controller;
 import com.restResource.StockTrader.entity.*;
 import com.restResource.StockTrader.entity.logging.ErrorEventLog;
 import com.restResource.StockTrader.entity.logging.UserCommandLog;
-import com.restResource.StockTrader.repository.AccountRepository;
+import com.restResource.StockTrader.service.AccountService;
 import com.restResource.StockTrader.repository.InvestmentRepository;
 import com.restResource.StockTrader.repository.SellRepository;
 import com.restResource.StockTrader.service.LoggingService;
@@ -26,7 +26,7 @@ public class SellController {
 
     private InvestmentRepository investmentRepository;
 
-    private AccountRepository accountRepository;
+    private AccountService accountService;
 
     private LoggingService loggingService;
 
@@ -35,13 +35,13 @@ public class SellController {
             SellRepository sellRepository,
             InvestmentRepository investmentRepository,
             LoggingService loggingService,
-            AccountRepository accountRepository) {
+            AccountService accountService) {
 
         this.quoteService = quoteService;
         this.loggingService = loggingService;
         this.sellRepository = sellRepository;
         this.investmentRepository = investmentRepository;
-        this.accountRepository = accountRepository;
+        this.accountService = accountService;
     }
 
     @PostMapping("/create")
@@ -67,7 +67,7 @@ public class SellController {
                             .build());
 
             //Don't hit the quote server if the user account doesn't exist
-            if( !accountRepository.accountExists(userId) ) throw new IllegalArgumentException("User account \"" + userId + "\" does not exist!");
+            if( !accountService.accountExists(userId) ) throw new IllegalArgumentException("User account \"" + userId + "\" does not exist!");
 
             //quote = quoteService.getQuote(stockSymbol, userId,transactionNum);
 
@@ -124,10 +124,10 @@ public class SellController {
 
         try {
             PendingSell pendingSell = claimMostRecentPendingSell(userId,transactionNum, CommandType.COMMIT_SELL);
-            accountRepository.updateAccountBalance(
+            accountService.updateAccountBalance(
                     userId,
                     pendingSell.getStockPrice() * pendingSell.getStockCount(),
-                    transactionNum,"TS1");
+                    transactionNum);
         } catch( Exception e ) {
             loggingService.logUserCommand(
                     UserCommandLog.builder()

--- a/StockTrader/src/main/java/com/restResource/StockTrader/entity/Account.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/entity/Account.java
@@ -1,10 +1,13 @@
 package com.restResource.StockTrader.entity;
 
+import com.restResource.StockTrader.entity.converter.LocalDateTimeToEpochConverter;
 import lombok.*;
 
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.validation.constraints.Min;
+import java.time.LocalDateTime;
 
 
 /**
@@ -22,4 +25,7 @@ public class Account {
     String userId;
     Integer lastTransactionNumber; //the last transaction to touch the account
     String lastServer; //the last server to touch the account
+    @Convert(converter = LocalDateTimeToEpochConverter.class)
+    @NonNull
+    LocalDateTime lastTransactionTime;
 }

--- a/StockTrader/src/main/java/com/restResource/StockTrader/repository/AccountRepository.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/repository/AccountRepository.java
@@ -10,13 +10,14 @@ public interface AccountRepository extends CrudRepository<Account, String> {
     @Modifying
     @Transactional
     @Query(value =
-            "INSERT INTO account VALUES (?1, ?2, ?3, ?4) " +
+            "INSERT INTO account VALUES (?1, ?2, ?3, ?4, ?5) " +
                     "ON CONFLICT (user_id) DO UPDATE " +
                     "SET amount = account.amount + ?2, " +
                     "last_transaction_number = ?3, " +
-                    "last_server = ?4",
+                    "last_server = ?4, " +
+                    "last_transaction_time = ?5",
         nativeQuery = true)
-    void updateAccountBalance(String userId, Integer amount, Integer transactionNum, String server);
+    void updateAccountBalance(String userId, Integer amount, Integer transactionNum, String server, Long time);
 
 
     // Need separate method for removing funds since the attempted insert
@@ -25,10 +26,11 @@ public interface AccountRepository extends CrudRepository<Account, String> {
     @Transactional
     @Query(value = "UPDATE account SET amount = amount - ?2, " +
                    "last_transaction_number = ?3, " +
-                   "last_server = ?4 " +
+                   "last_server = ?4, " +
+                   "last_transaction_time = ?5 " +
                    "WHERE user_id = ?1",
             nativeQuery = true)
-    Integer removeFunds(String userId, Integer amount, Integer transactionNum, String server);
+    Integer removeFunds(String userId, Integer amount, Integer transactionNum, String server, Long time);
 
     //Need to check if user account exists to prevent unnecessary quoteServer requests in BuyController
     @Query(value = "SELECT EXISTS( SELECT 1 FROM account WHERE user_id = ?1)", nativeQuery = true)

--- a/StockTrader/src/main/java/com/restResource/StockTrader/service/AccountService.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/service/AccountService.java
@@ -1,0 +1,40 @@
+package com.restResource.StockTrader.service;
+
+import com.restResource.StockTrader.entity.converter.LocalDateTimeToEpochConverter;
+import com.restResource.StockTrader.repository.AccountRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class AccountService {
+    private AccountRepository accountRepository;
+
+    private static LocalDateTimeToEpochConverter converter = new LocalDateTimeToEpochConverter();
+
+    public AccountService(AccountRepository accountRepository) {
+        this.accountRepository = accountRepository;
+    }
+
+    public void updateAccountBalance(String userId, int amount, int transactionNum) {
+        accountRepository.updateAccountBalance(
+                userId,
+                amount,
+                transactionNum,
+                "TS1",
+                converter.convertToDatabaseColumn(LocalDateTime.now()));
+    }
+
+    public Integer removeFunds(String userId, int amount, int transactionNum) {
+        return accountRepository.removeFunds(
+                userId,
+                amount,
+                transactionNum,
+                "TS1",
+                converter.convertToDatabaseColumn(LocalDateTime.now()));
+    }
+
+    public Boolean accountExists(String userId) {
+        return accountRepository.accountExists(userId);
+    }
+}

--- a/StockTrader/src/main/java/com/restResource/StockTrader/service/BuyTriggerService.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/service/BuyTriggerService.java
@@ -4,7 +4,7 @@ import com.restResource.StockTrader.entity.BuyTrigger;
 import com.restResource.StockTrader.entity.CommandType;
 import com.restResource.StockTrader.entity.Quote;
 import com.restResource.StockTrader.entity.logging.ErrorEventLog;
-import com.restResource.StockTrader.repository.AccountRepository;
+import com.restResource.StockTrader.service.AccountService;
 import com.restResource.StockTrader.repository.BuyTriggerRepository;
 import com.restResource.StockTrader.repository.InvestmentRepository;
 import org.springframework.core.task.TaskExecutor;
@@ -18,7 +18,7 @@ public class BuyTriggerService {
     private QuoteService quoteService;
     private BuyTriggerRepository buyTriggerRepository;
     private TaskExecutor taskExecutor;
-    private AccountRepository accountRepository;
+    private AccountService accountService;
     private InvestmentRepository investmentRepository;
     private LoggingService loggingService;
 
@@ -27,11 +27,11 @@ public class BuyTriggerService {
                              BuyTriggerRepository buyTriggerRepository,
                              TaskExecutor taskExecutor,
                              InvestmentRepository investmentRepository,
-                             AccountRepository accountRepository){
+                             AccountService accountService){
         this.quoteService = quoteService;
         this.buyTriggerRepository = buyTriggerRepository;
         this.taskExecutor = taskExecutor;
-        this.accountRepository = accountRepository;
+        this.accountService = accountService;
         this.investmentRepository = investmentRepository;
         this.loggingService = loggingService;
     }
@@ -63,7 +63,7 @@ public class BuyTriggerService {
                         Integer refund = amount % quote.getPrice();
                         if (refund > 0) {
                             //if the user wanted to buy for cheaper then the cost, refund the difference
-                            accountRepository.updateAccountBalance(userId, refund, transactionNum, "TS1");
+                            accountService.updateAccountBalance(userId, refund, transactionNum);
                         }
                         investmentRepository.insertOrIncrement(userId, stockSymbol, amount);
                         buyTriggerRepository.delete(buyStockSnapshot.get());

--- a/StockTrader/src/main/java/com/restResource/StockTrader/service/SellTriggerService.java
+++ b/StockTrader/src/main/java/com/restResource/StockTrader/service/SellTriggerService.java
@@ -2,12 +2,13 @@ package com.restResource.StockTrader.service;
 
 import com.restResource.StockTrader.entity.Quote;
 import com.restResource.StockTrader.entity.SellTrigger;
-import com.restResource.StockTrader.repository.AccountRepository;
+import com.restResource.StockTrader.service.AccountService;
 import com.restResource.StockTrader.repository.InvestmentRepository;
 import com.restResource.StockTrader.repository.SellTriggerRepository;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -16,7 +17,7 @@ public class SellTriggerService {
     private QuoteService quoteService;
     private SellTriggerRepository sellTriggerRepository;
     private TaskExecutor taskExecutor;
-    private AccountRepository accountRepository;
+    private AccountService accountService;
     private InvestmentRepository investmentRepository;
     private LoggingService loggingService;
 
@@ -25,11 +26,11 @@ public class SellTriggerService {
                              SellTriggerRepository sellTriggerRepository,
                              InvestmentRepository investmentRepository,
                              TaskExecutor taskExecutor,
-                             AccountRepository accountRepository){
+                             AccountService accountService){
         this.quoteService = quoteService;
         this.sellTriggerRepository = sellTriggerRepository;
         this.taskExecutor = taskExecutor;
-        this.accountRepository = accountRepository;
+        this.accountService = accountService;
         this.loggingService = loggingService;
         this.investmentRepository = investmentRepository;
     }
@@ -63,7 +64,7 @@ public class SellTriggerService {
                         if (stocksReserved > stocksToSell) {
                             investmentRepository.insertOrIncrement(userId, stockSymbol, stocksReserved - stocksToSell);
                         }
-                        accountRepository.updateAccountBalance(userId, profit, transactionNum, "TS1");
+                        accountService.updateAccountBalance(userId, profit, transactionNum);
                         sellTriggerRepository.delete(sellStockSnapshot.get());
                         return;
                     }


### PR DESCRIPTION
There was an issue with different computers not having the same time that messed with out calculated TPS. To fix this, I've modified account_transaction_log to use the transaction servers time. I did not see any other database calls that used database server time, but if there are, they will need to be modified as well. 

-Added timestamp column to account to be used for account_transaction_log.
-Added AccountService which adds the server name and converted timestamp to update and remove funds since I thought it was nicer then every class needing to create a LocalDateTimeToEpochConverter.